### PR TITLE
Fix memory_get_ptr function

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -195,7 +195,9 @@ void *memory_get_ptr(vm_t *vm, u64 addr)
         return 0x0;
     }
 
-    return ((u8 *)entry->memory_ptr) + addr;
+    u64 ptr = (u64)entry->memory_ptr;
+
+    return (void*) (ptr + (addr - entry->guest_phys));
 }
 
 struct e820_table *e820_table_get(vm_t *vm)


### PR DESCRIPTION
The function memory_get_ptr as returning an invalid pointer when guest_phys is different than 0